### PR TITLE
Documentation enhancements and a couple of fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,12 @@
 /doc/html/
 /doc/.venv/
 /dist/
+/.cache/
 /.tox/
+
+# VIM recovery files
+*.swp
+# Emacs backups
+*~
+# And Python compiled stuff
+*.pyc

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,8 @@
-CLDomain
+CLDomain 
+
+.. image https://travis-ci.org/travis-ci/travis-build.png?branch=master
+   :target: https://travis-ci.org/bscottm/sphinxcontrib-cldomain/
+
 ========
 
 CLDomain is a Common Lisp domain for `Sphinx Documentation Generator`_.

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
 CLDomain 
+========
 
-.. image https://travis-ci.org/travis-ci/travis-build.png?branch=master
+.. image:: https://travis-ci.org/travis-ci/travis-build.png?branch=master
    :target: https://travis-ci.org/bscottm/sphinxcontrib-cldomain/
 
-========
 
 CLDomain is a Common Lisp domain for `Sphinx Documentation Generator`_.
 Sphinx is a mulit-language documentation tool.  This project extends

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@ CLDomain
 ========
 
 .. image:: https://travis-ci.org/travis-ci/travis-build.png?branch=master
-   :target: https://travis-ci.org/bscottm/sphinxcontrib-cldomain/
+   :target: https://travis-ci.org/russell/sphinxcontrib-cldomain/
 
 
 CLDomain is a Common Lisp domain for `Sphinx Documentation Generator`_.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,7 +48,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'cldomain'
-copyright = u'2011-2014, Russell Sim'
+copyright = u'2011-2015, Russell Sim'
 
 googleanalytics_id = "UA-28069739-3"
 if os.environ.get("GOOGLE_ANALYTICS"):
@@ -61,7 +61,15 @@ cl_systems = [{"name": "sphinxcontrib.cldomain.doc",
                "packages": ["sphinxcontrib.cldomain.doc",
                             "sphinxcontrib.cldomain.doc-alt"]}]
 
-cl_quicklisp = path.expandvars('$HOME/.quicklisp/')
+# Russell's Quicklisp is in $HOME/.quicklisp, so look there first:
+if path.exists(path.expandvars('$HOME/.quicklisp/')):
+    cl_quicklisp = path.expandvars('$HOME/.quicklisp/')
+else:
+    # Everyone else who isn't Russell Sims... :-)
+    cl_quicklisp = path.expandvars('$HOME/quicklisp/')
+
+# Grab alternative lisps from the CL_LISPS environment variable:
+cl_lisps = os.environ.get("CL_LISPS", None)
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/doc.lisp
+++ b/doc/doc.lisp
@@ -22,12 +22,16 @@
            #:example-class
            #:example-macro
            #:*example-variable*
+	   #:*example-variable-2*
            #:example-generic))
 
 (in-package :sphinxcontrib.cldomain.doc)
 
 (defvar *example-variable* "value"
   "This is an example variable.")
+
+(defvar *example-variable-2* "another value"
+  "This example has additional text.")
 
 (defun example-function (arg1 arg2 &optional (arg3 #'sort) &key (kw *example-variable*))
   "The CL Domain will try and convert any uppercase symbols into
@@ -53,12 +57,8 @@ for example :KEYWORD."
 
 
 (defmethod example-generic ((arg1 example-class) (arg2 (eql :test)) &optional arg3)
-  "The CL Domain will try and convert any uppercase symbols into
-reference for example EXAMPLE-FUNCTION or a hyperspec link LIST.  Any
-unmatched symbols are converted to literals as is ARG1, ARG2 and ARG3.
-Explicit package references will also help resolve symbol sources
-COMMON-LISP:CDR.  Keywords are also detected for example :TEST."
-  (list arg1 arg2 arg3))
+    "This is the first specialized version of example-generic."
+    (list arg1 arg2 arg3))
 
 (defmethod example-generic ((arg1 example-class) (arg2 (eql :test1)) &optional arg3)
   "The second test method."

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -81,14 +81,10 @@ LISP to use
 *gcl*, *abcl*, *scl* (refer to ``cl-launch -h`` for the current search list).
 
 From time to time, you may run into issues with ``cl-launch``, CLDomain and one
-of the Lisp interpreters/compilers. Here are a couple of examples:
-
-- **clisp**: Can't find ASDF or Quicklisp on startup because *"-norc"* is passed
-  on the command line. Apparently, *"-norc"* causes no startup file to be read,
-  including *clisp*'s own system startup that tells it ASDF's location.
-  
-- **sbcl**: Some random package decides it needs to modify the standard
-  readtable, causing *sbcl* to complain loudly and exit with an error.  
+of the Lisp interpreters/compilers. For example, you use **sbcl** and some
+random package decides it needs to modify the standard readtable, causing
+*sbcl* to complain loudly and exit with an error. Solution: Yell loudly at the
+package owner or use another Lisp.
 
 You can force ``cl-launch`` to use a different Lisp or change its search order
 though the ``cl_lisps`` configuration option:
@@ -117,6 +113,38 @@ snippet <conf_py_block>`.  Here is how you would use it:
   % env CL_LISPS="ccl ecl" make html
   % env CL_LISPS="ccl ecl" ./script-to-generate-documentation
 
+``cl-launch`` can't find *ASDF*
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you get the following message, followed by an enormous traceback:
+
+.. code-block:: shell
+
+   *** - Could not load ASDF.
+
+Then ensure that you've properly installed *ASDF* so that ``cl-launch`` can find it
+in ``$HOME/common-lisp/asdf`` and that
+``$HOME/common-lisp/asdf/build/asdf.lisp`` exists.  If you don't have ASDF
+installed, here's the quick start recipe:
+
+.. code-block:: shell
+
+   $ cd $HOME
+   $ mkdir common-lisp
+   $ cd common-lisp
+
+   # If you use curl:
+   $ curl -O http://common-lisp.net/project/asdf/asdf.tar.gz
+
+   # Alternatively, wget:
+   $ wget http://common-lisp.net/project/asdf/asdf.tar.gz
+
+   $ tar xzf asdf.tar.gz
+
+   # You should now have an asdf-X.Y.Z subdirectory, e.g., asdf-3.1.6:
+   $ ln -sf asdf-3.1.6 asdf
+   $ cd asdf
+   $ make
 
 Documenting Your Common Lisp Code
 =================================

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,6 +3,8 @@ About
 
 CLDomain is an extension for the Sphinx documentation generation tool
 that allow sphinx to generate documentation for Common Lisp libraries.
+Documentation is extracted from the various entity's documentation
+strings, loaded from ASDF systems and associated internal packages.
 
 Hyperspec is a cross referencing extension that supports linking to
 the hyperspec.
@@ -37,93 +39,174 @@ Releases are hosted on `github`_ or `pypi`_.  The `source`_ is also available.
 Configuration
 -------------
 
-Edit you `conf.py` file and add CLDomain and Hyperspec to your enabled
-extensions.
+Configuring CLDomain involves two actions: (a) adding the extensions to the
+extension list, (b) telling CLDomain the systems and packages to load.
 
+.. _conf_py_block:
 .. code-block:: python
 
-   extensions.extend(['sphinxcontrib.cldomain',
-                      'sphinxcontrib.hyperspec'])
+  from os.path import join, dirname, realpath, expandvars
 
+  # Extensions: add 'sphinxcontrib.cldomain' and 'sphinxcontrib.hyperspec',
+  # just like this example:
+  extensions = [
+      'sphinx.ext.intersphinx',
+      'sphinxcontrib.cldomain',
+      'sphinxcontrib.hyperspec'
+  ]
 
-System symbols to load
-^^^^^^^^^^^^^^^^^^^^^^
-
-The path to each package needs to the lisp_packages configuration
-option.  In this example the conf.py is in a doc directory and the ASD
-file is in the parent directory.
-
-The valid keys for each of the systems in the systems dict:
-
-**name**
-   The name of the system to load.
-
-**path**
-   The path to the system.
-
-**packages**
-   A list of the packages to extract symbol information from.
-
-.. code-block:: python
-
-   from os.path import join, dirname, realpath
-   cl_systems = [{"name": "cl-git",
-                  "path": join(dirname(realpath(__file__)), "../")),
-                  "packages": ["cl-git"]}]
-
-Quicklisp Location
-^^^^^^^^^^^^^^^^^^
-
-To set the location of quicklisp in conf.py add a quicklisp variable
-with the value set to it's location.
-
-.. code-block:: python
-
-   from os.path import expandvars
-   cl_quicklisp = expandvars('$HOME/quicklisp/')
+  # --- CL domain customizations:
+  #
+  # cl_systems: The systems and packages from which to extract documentation:
+  #
+  # Note: This conf.py sits in a subdirectory below ("../"), relative to where
+  # the "my-system.asd" system description file lives:
+  cl_systems = [{"name": "my-system",
+                 "path": join(dirname(realpath(__file__)), "../"),
+                 "packages": ["my-package-1", "my-package-2"]}]
+  # cl_quicklisp: The default is $HOME/quicklisp. Shown here for completeness,
+  # and you can comment it out:
+  cl_quicklisp = expandvars('$HOME/quicklisp')
+  # cl_lisps: You could hardcode this to a string, or use an environment variable
+  # as shown:
+  cl_lisps = environ.get('CL_LISPS', None)
+  # Ensure that the default highlighting language is CL:
+  highlight_language = 'common-lisp'
 
 LISP to use
 ^^^^^^^^^^^
 
-To configure a specific lisp executable search order use.
+``cl-launch`` searches for a Lisp interpreter/compiler in a parciular order:
+*sbcl*, *clisp*, *ccl*, *ecl*, *cmucl*, *gclcvs*, *lispworks*, *allegro*,
+*gcl*, *abcl*, *scl* (refer to ``cl-launch -h`` for the current search list).
+
+From time to time, you may run into issues with ``cl-launch``, CLDomain and one
+of the Lisp interpreters/compilers. Here are a couple of examples:
+
+- **clisp**: Can't find ASDF or Quicklisp on startup because *"-norc"* is passed
+  on the command line. Apparently, *"-norc"* causes no startup file to be read,
+  including *clisp*'s own system startup that tells it ASDF's location.
+  
+- **sbcl**: Some random package decides it needs to modify the standard
+  readtable, causing *sbcl* to complain loudly and exit with an error.  
+
+You can force ``cl-launch`` to use a different Lisp or change its search order
+though the ``cl_lisps`` configuration option:
 
 .. code-block:: python
 
    cl_lisps = "sbcl ecl"
 
+Instead of hard coding the string, an environment variable is a somewhat
+cleaner, more flexible approach, as is shown in the :ref:`configuration code
+snippet <conf_py_block>`.  Here is how you would use it:
 
-Documentation
-=============
+.. code-block:: sh
 
-All directives support the ``nodoc`` option that will prevent them
-from pulling the documentation string from Common Lisp.  Argument
-lists and specializers will still be printed::
+  ## If you use 'make html' (bash and zsh):
 
-       .. cl:macro:: example-macro
-          :nodoc:
+  $ CL_LISPS="ccl ecl" make html
 
-          No documentation
+  ## If you use a script (bash and zsh):
+
+  $ CL_LISPS="ccl ecl" ./script-to-generate-documentation
+
+  ## Build script for C-shell derivatives (tcsh) and non-bash/zsh
+  ## and works for bash/zsh as well:
+
+  % env CL_LISPS="ccl ecl" make html
+  % env CL_LISPS="ccl ecl" ./script-to-generate-documentation
+
+
+Documenting Your Common Lisp Code
+=================================
+
+Common Lisp docstrings
+----------------------
+
+CLDomain collects the documentation strings for the package-exported symbols in
+each system enumerated in the ``cl_systems`` configuration variable, which
+CLDomain appends to the symbol's signature. You can include additional
+documentation after the directive and it will also get included in the
+Spinx-generated output. The output template looks like:
+
+    *type*: *signature*
+
+    *symbol-docstring*
+
+    Any additional text you decide to add here.
+
+For an example, follow :ref:`this <variable2>` link or read on.
+
+
+Don't include the docstring: :nodoc:
+------------------------------------
+
+CLDomain inserts the documentation strings associated with symbols in
+your systems and packages loaded by the ``cl_systems`` configuration
+directive. Sometimes, this isn't the right thing to do, when, instead,
+you'd prefer to provide separate (non-docstring) documentation. That's
+what the ``:nodoc`` option does.
+
+Note: Argument lists and specializers will still be printed, as in this
+example::
+
+
+      .. cl:macro:: example-macro
+        :nodoc:
+
+        No documentation from the ``example-macro`` documentation string.
+
+Code:
+
+.. code-block:: common-lisp
+
+   (defmacro example-macro ((arg1 arg2) &body arg3)
+     "The CL Domain will try and convert any uppercase symbols into
+   reference for example EXAMPLE-FUNCTION or a hyperspec link LIST.  Any
+   unmatched symbols are converted to literals as is ARG1, ARG2 and ARG3.
+   Explicit package references will also help resolve symbol sources
+   COMMON-LISP:CDR.  Keywords are also detected for example :TEST."
+     arg3)
+
+
+Output:
 
 .. cl:macro:: example-macro
    :nodoc:
 
-   No documentation
+   No documentation from the ``example-macro`` documentation string.
 
-Package
--------
 
-.. rst:directive:: .. cl:package:: symbol-name
+Packages
+--------
 
-   The cl:package directive specifies the package that all the subsequent
-   directives will look up when trying to resolve a symbol.::
+CLDomain, like Common Lisp, needs to know the current package when resolving symbols. The
+``:cl:package:`` directive is the CLDomain equivalent of ``(in-package ...)``. You can switch
+between packages at any time in the documentation file using this directive.
+
+.. rst:directive:: .. cl:package:: package
+
+   Use ``package`` as the package name when resolving symbols to documentation::
 
       .. cl:package:: sphinxcontrib.cldomain.doc
+
+   For multi-package documentation in the same Sphinx documentation file::
+
+      .. cl:package:: sphinxcontrib.cldomain.doc
+
+      documentation... documentation... documentation...
+
+      .. cl:package:: org.coolness.my.code
+
+      foo... bar... baz... lemon odor quux!!!
+
 
 .. cl:package:: sphinxcontrib.cldomain.doc
 
 
-Variable
---------
+Variables
+---------
 
 .. rst:directive::  .. cl:variable:: symbol-name
 
@@ -132,122 +215,203 @@ Variable
 
        .. cl:variable:: *example-variable*
 
-Example:
+Code:
+
+.. code-block:: common-lisp
+
+    (defvar *example-variable* "value"
+      "This is an example variable.")
+
+Output:
 
 .. cl:variable:: *example-variable*
 
-   extra description can be appended to further explain the
-   functionality.  This doesn't need to appear in the lisp
-   code. Instead it can be added to the rst files and it will be
-   appended to the documentation.
+.. _variable2:
 
-Function
---------
+You can include additional text, which appears after the docstring (unless you
+use the ``:nodoc:`` option)::
+
+      .. cl:variable:: *example-variable-2*
+
+         This variable requires more explanitory text after its docstring. Because,
+         more text means more clarity and further explains the intent of the original
+         software developer.
+
+Code:
+
+.. code-block:: common-lisp
+
+  (defvar *example-variable-2* "another value"
+    "This example has additional text.")
+
+Output:
+
+.. cl:variable:: *example-variable-2*
+
+   This variable requires more explanitory text after its docstring. Because,
+   more text means more clarity and further explains the intent of the original
+   software developer.
+
+Functions
+---------
 
 .. rst:directive:: .. cl:function:: symbol-name
 
-   The cl:function directive will resolve the arguments and documentation
-   from the common lisp definition::
+   Outputs the function's signature (arguments)::
 
        .. cl:function:: example-function
 
-Example:
+.. _hyperspec_example:
+
+Code:
+
+.. code-block:: common-lisp
+
+  (defun example-function (arg1 arg2 &optional (arg3 #'sort) &key (kw *example-variable*))
+    "The CL Domain will try and convert any uppercase symbols into
+  reference for example EXAMPLE-FUNCTION, EXAMPLE-GENERIC or a hyperspec
+  link LIST.  Any unmatched symbols are converted to literals as is
+  ARG1, ARG2 and ARG3.  Explicit package references will also help
+  resolve symbol sources COMMON-LISP:CAR.  Keywords are also detected
+  for example :KEYWORD."
+    (list arg1 arg2 arg3))
+
+Output:
 
 .. cl:function:: example-function
 
 
-Macro
---------
+Macros
+------
 
 .. rst:directive:: .. cl:macro:: symbol-name
 
-   The cl:macro directive will resolve the arguments and documentation
-   from the common lisp definition::
+   Emit the macro's signature and documentation::
 
        .. cl:macro:: example-macro
 
-Example:
+
+Code:
+
+.. code-block:: common-lisp
+
+   (defmacro example-macro ((arg1 arg2) &body arg3)
+     "The CL Domain will try and convert any uppercase symbols into
+   reference for example EXAMPLE-FUNCTION or a hyperspec link LIST.  Any
+   unmatched symbols are converted to literals as is ARG1, ARG2 and ARG3.
+   Explicit package references will also help resolve symbol sources
+   COMMON-LISP:CDR.  Keywords are also detected for example :TEST."
+     arg3)
+
+Output:
 
 .. cl:macro:: example-macro
 
 
-Class
------
+Types (aka CLOS Classes)
+------------------------
 
-.. rst:directive:: .. cl:class:: symbol-name
+.. rst:directive:: .. cl:type:: symbol-name
 
-   The cl:function directive will resolve the arguments and documentation
-   from the common lisp definition::
+   The ``:cl:type:`` directive emits Common Lisp Object System (CLOS) class documentation::
 
-       .. cl:class:: example-class
+       .. cl:type:: example-class
 
-Example:
+   The ``:noinitargs:`` option can be specified to exclude the class' list of ``:initarg``
+   initialzers that are ordinarily included in the class' signature::
+
+       .. cl:type:: example-class
+          :noinitargs:
+
+
+   Note: There is no mechanism or directive to document individual slots at the moment.
+
+Code:
+
+.. code-block:: common-lisp
+
+  (defclass example-class ()
+    ((slot1 :initarg :slot1 :accessor slot1
+            :initform "default"
+            :documentation "the first slot.")
+     (slot2 :initarg :slot2 :accessor slot2
+            :documentation "the second slot."))
+    (:documentation "An example class."))
+
+Output:
 
 .. cl:type:: example-class
 
 
-Generics
---------
+Generics and Methods
+--------------------
 
 .. rst:directive:: .. cl:generic:: symbol-name
 
-   The cl:generic directive will resolve the arguments and
-   documentation from the common lisp definition.  It will also
-   accumulate a list of the specialises and link to the types that
-   this generic specialises on.::
+   The ``:cl:generic:`` directive emits the documentation for a generic function and
+   its specializers::
 
        .. cl:generic:: example-generic
 
-Example:
+Code:
+
+.. code-block:: common-lisp
+
+  (defgeneric example-generic (arg1 arg2 &optional arg3)
+    (:documentation "A test generic function."))
+
+Output:
 
 .. cl:generic:: example-generic
 
 
-Methods
--------
-
 .. rst:directive:: .. cl:method:: symbol-name (specializer)
 
-   The cl:method directive will resolve the arguments and
-   documentation from the common lisp dbenigntion::
+   The ``:cl:method`` emits the documentation for generic method specializers::
 
        .. cl:method:: example-generic example-class :test
 
-   For the time being all specializing arguments that aren't in the
-   current package need to be qualified with a package.  E.g
-   ``common-lisp:t``
+   For the time being, all specializing arguments that aren't in the current
+   package must be qualified with a package, e.g., ``common-lisp:t``
 
-   If you would like to prevent the method from resolving to the
-   generics forms documentation string this can be suppressed using
-   the ``noinherit`` option like::
+Code:
+
+.. code-block:: common-lisp
+
+  (defmethod example-generic ((arg1 example-class) (arg2 (eql :test)) &optional arg3)
+    "This is the first specialized version of example-generic."
+    (list arg1 arg2 arg3))
+
+Output:
+
+.. cl:method:: example-generic example-class :test
+
+
+Note: The output for a specializing method will include its parent generic
+function's documentation string, i.e., specializing methods inherit their
+parent generic's docstring. The ``:noinherit:`` option suppresses this
+behavior::
 
        .. cl:method:: example-generic example-class :test
           :noinherit:
 
-Example:
-
 .. cl:method:: example-generic example-class :test
-
-Multiple Packages
------------------
-
-.. cl:package:: sphinxcontrib.cldomain.doc-alt
+   :noinherit:
 
 
-.. rst:directive:: .. cl:function:: symbol-name
+Hyperspec References
+--------------------
 
-   The cl:function directive will resolve the arguments and documentation
-   from the common lisp definition::
+Generating a reference is very easy (and you've probably noticed already if you've read the Common Lisp
+code snippets used to generate the examples). To generate a Hyperspec reference:
 
-       .. cl:package:: sphinxcontrib.cldomain.doc-alt
+1. THE COMMON LISP SYMBOL NAME IS IN ALL CAPS, LIKE LIST OR FORMAT. (No, the
+   documentation isn't shouting at you. It's the normal Lisp convention for
+   symbols.
 
-       .. cl:function:: example-function
+2. Prefix the symbol name with ``COMMON-LISP:``, e.g., ``COMMON-LISP:CAR``
 
-Example:
-
-.. cl:package:: sphinxcontrib.cldomain.doc-alt
-
-.. cl:function:: example-function
+The :ref:`cl:function: example<hyperspec_example>` has an example of Hyperspec-ing in its example code.
 
 
 Changelog

--- a/sphinxcontrib/cldomain.lisp
+++ b/sphinxcontrib/cldomain.lisp
@@ -220,7 +220,10 @@ possible symbol names."
                  (when literal
                    (write-string (encode-literal literal) out))
                  (write-string rest out))
-               (unread-char char stream)
+               ;; Don't push newlines back onto the input stream -- this can cause
+               ;; some CL's to spew.
+               (unless (eql char #\Newline)
+                 (unread-char char stream))
                (setf possible-symbol nil)
                (setf possible-symbols nil))
               ;; if the current char is a white space, then check if the
@@ -289,6 +292,11 @@ possible symbol names."
   (encode-function-documentation*
    symbol type (or (documentation symbol type) "")))
 
+;; CLISP-ism (might be other CL's as well.)
+(defmethod encode-function-documentation (symbol (type (eql 'compiled-function)))
+  (encode-function-documentation*
+   symbol type (or (documentation symbol 'function) "")))
+
 (defmethod encode-function-documentation (symbol (type (eql 'macro)))
   (encode-function-documentation*
    symbol type (or (documentation symbol 'function) "")))
@@ -352,6 +360,7 @@ possible symbol names."
       (with-object ()
         (encode-symbol-status symbol package)
         (when (symbol-function-type symbol)
+          ;; (format *error-output* "symbol ~S type ~S~%"symbol (symbol-function-type symbol))
           (encode-function-documentation symbol (symbol-function-type symbol)))
         (when (class-p symbol)
           (encode-value-documentation symbol 'type))
@@ -387,7 +396,15 @@ possible symbol names."
         ('package (push value packages))
         ('path (push value paths))))
     (dolist (path paths)
-      (push (truename (pathname path)) asdf:*central-registry*))
+      (let ((path-pathname (pathname path)))
+        ;; CLISP's truename spews if path is a directory, whereas ext:probe-filename
+        ;; will generate a directory-truename for directories without spewing...???
+        #+clisp
+          (let ((dir-truename (ext:probe-pathname path)))
+            (when dir-truename
+              (push  dir-truename asdf:*central-registry*)))
+        #-(or clisp)
+          (push (truename path-pathname) asdf:*central-registry*)))
     (let ((my-system (car systems)))
       (let ((*standard-output* *error-output*))
         (ql:quickload my-system :prompt nil))

--- a/sphinxcontrib/cldomain.lisp
+++ b/sphinxcontrib/cldomain.lisp
@@ -247,10 +247,11 @@ possible symbol names."
                  (write-string rest out))))))))
 
 (defun arglist (symbol)
-  #+sbcl
-  (sb-introspect:function-lambda-list symbol)
-  #+ecl
-  (ext:function-lambda-list name))
+  #+sbcl  (sb-introspect:function-lambda-list symbol)
+  #+clisp (sys::arglist symbol)
+  #+ccl (ccl:arglist symbol)
+  #+ecl   (ext:function-lambda-list symbol)
+  #-(or sbcl clisp ccl ecl) (error "arglist not available for this Lisp."))
 
 (defun encode-symbol-status (symbol package)
   (multiple-value-bind
@@ -337,12 +338,13 @@ possible symbol names."
 
 (defun class-p (symbol)
   "Return T if the symbol is a class."
-  (eql (sb-int:info :type :kind symbol) :instance))
+  #+sbcl (eql (sb-int:info :type :kind symbol) :instance)
+  #-sbcl (find-class symbol nil))
 
 (defun variable-p (symbol)
   "Return T if the symbol is a bound variable."
-  (and (sb-int:info :variable :kind symbol)
-                         (boundp symbol)))
+  (and #+sbcl (sb-int:info :variable :kind symbol)
+              (boundp symbol)))
 
 (defun symbols-to-json (&optional (package *current-package*))
   (do-external-symbols (symbol package)

--- a/sphinxcontrib/cldomain.py
+++ b/sphinxcontrib/cldomain.py
@@ -34,6 +34,7 @@ import subprocess
 from StringIO import StringIO
 from docutils import nodes
 from docutils.statemachine import string2lines, StringList
+import pprint
 
 from sphinx import addnodes
 from sphinx.util.console import red
@@ -77,7 +78,6 @@ def node_to_dict(node):
 def debug_print(node):
     """Useful in pdb sessions"""
     node = node_to_dict(node)
-    import pprint
     pprint.pprint(node)
 
 
@@ -415,6 +415,7 @@ class CLsExp(ObjectDescription):
     option_spec = {
         'nodoc': bool_option,
         'noindex': bool_option,
+        'noinitargs': bool_option,
     }
 
     def handle_signature(self, sig, signode):
@@ -443,9 +444,14 @@ class CLsExp(ObjectDescription):
 
         # Add Slots
         slots = SLOTS[package].get(sig.upper())
-        if slots:
+        if slots and "noinitargs" not in self.options:
             # TODO add slot details if describing a class
-            pass
+            for slot in slots:
+                initarg = slot.get(u'initarg')
+                if initarg and initarg.lower() != 'nil':
+                    slotarg = addnodes.literal_emphasis(slot.get(u'name'), slot.get(u'name'))
+                    slotsig = initarg.lower() + u' '
+                    signode.append(addnodes.desc_optional(slotsig, slotsig, slotarg))
 
         symbol_name = sig
         if not symbol_name:
@@ -751,6 +757,7 @@ class CLDomain(Domain):
         'function': CLXRefRole(),
         'generic': CLXRefRole(),
         'method': CLXRefRole(),
+        'type': CLXRefRole(),
     }
     initial_data = {
         'symbols': {},
@@ -841,22 +848,6 @@ class CLDomain(Domain):
                 yield (refname, refname, type, docname, refname, 1)
 
 
-def code_regions(text):
-    io = StringIO(text)
-    output = StringIO()
-    indent = False
-    for line in io:
-        if indent is False and (line.startswith(" ") or line.startswith("\t")):
-            # TODO detect if its a REPL.
-            output.write("\n.. code-block:: common-lisp\n\n")
-            indent = True
-        if indent is True and not (line.startswith(" ") or line.startswith("\t")):
-            indent = False
-        output.write(line)
-    output.seek(0)
-    return output.read()
-
-
 def save_cldomain_output(output):
     """Save a copy of the clgit output for debugging."""
     fd, path = tempfile.mkstemp('.log', 'cldomain-err-')
@@ -891,6 +882,7 @@ def index_packages(systems, system_paths, packages, quicklisp, lisps):
 
     try:
         lisp_data = json.loads(output)
+        #pprint.pprint(lisp_data)
     except:
         dump_path = save_cldomain_output(raw_output)
         error = sys.stderr
@@ -919,7 +911,7 @@ def index_packages(systems, system_paths, packages, quicklisp, lisps):
                 cl_type = type
 
             # enable symbol references for symbols
-            DOC_STRINGS[package][name][cl_type] = code_regions(v[type])
+            DOC_STRINGS[package][name][cl_type] = v[type]
 
         # extract methods
         if "methods" in v:
@@ -936,7 +928,7 @@ def index_packages(systems, system_paths, packages, quicklisp, lisps):
             def parse_doc(doc):
                 if doc is None:
                     doc = ""
-                return code_regions(doc)
+                return doc
 
             methods = dict([(parse_method(method), parse_doc(doc))
                             for method, doc in v["methods"].items()])
@@ -1087,7 +1079,7 @@ def setup(app):
                  text=(v_text_clparameter, d_clparameter))
     app.add_config_value('cl_packages', {}, 'env')
     app.add_config_value('cl_systems', {}, 'env')
-    app.add_config_value('cl_quicklisp', "", 'env')
+    app.add_config_value('cl_quicklisp', path.expandvars("$HOME/quicklisp"), 'env')
     app.add_config_value('cl_show_defaults', False, True)
     app.add_config_value('cl_lisps', None, 'env')
     app.connect('builder-inited', load_packages)

--- a/sphinxcontrib/cldomain.py
+++ b/sphinxcontrib/cldomain.py
@@ -1136,7 +1136,7 @@ def cl_launch_args(lisps=None,
     args.extend(["--init", quicklisp,
                  "--init", system,
                  "--init", "(asdf:initialize-source-registry)",
-                 "--init", "(require 'quicklisp)",
+		 "--init", "(asdf:require-system :quicklisp)",
                  "--init", quickload,
                  "--init", "(%s)" % main_function])
     return args

--- a/sphinxcontrib/cldomain.py
+++ b/sphinxcontrib/cldomain.py
@@ -756,8 +756,10 @@ class CLDomain(Domain):
         'symbol': CLXRefRole(),
         'function': CLXRefRole(),
         'generic': CLXRefRole(),
-        'method': CLXRefRole(),
+	'macro': CLXRefRole(),
+	'variable': CLXRefRole(),
         'type': CLXRefRole(),
+        'method': CLXRefRole(),
     }
     initial_data = {
         'symbols': {},

--- a/sphinxcontrib/test.lisp
+++ b/sphinxcontrib/test.lisp
@@ -36,6 +36,7 @@
                (multiple-value-bind (symbol literal rest)
                    (find-best-symbol '("COMMON-LISP:LIST."
                                        "COMMON-LISP:LIST"))
+                   (declare   (ignore literal))
                  (list symbol rest))))))
 
 (test find-best-symbol-one

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,9 @@ envlist=py27
 
 # test running
 [testenv]
-deps=
-    pytest
+# No additional dependencies.
+deps= 
 commands=
-    py.test
     python tests/run_lisp_tests.py
 
 [testenv:doc]


### PR DESCRIPTION
A couple of bug fixes and an enhancement for consideration:

- Make references to CLOS classes/types work; `:cl:type:`\``my-class`\` links to its respective documentation.
- Remove breakage caused by `code_region()`. Just ask the user to set highlight_lang correctly in the CLDomain configuration documentation's snippet. Really: `code_region()` is __Just Plain Evil__(tm).
- Add slot initargs to class signatures. Can be turned off via `:noinitargs:` option.
- Improve documentation.