### PR TITLE
More fixes and tweaks

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -65,11 +65,13 @@ cl_systems = [{"name": "sphinxcontrib.cldomain.doc",
 if path.exists(path.expandvars('$HOME/.quicklisp/')):
     cl_quicklisp = path.expandvars('$HOME/.quicklisp/')
 else:
-    # Everyone else who isn't Russell Sims... :-)
+    # Everyone else who isn't Russell Sim... :-)
     cl_quicklisp = path.expandvars('$HOME/quicklisp/')
 
 # Grab alternative lisps from the CL_LISPS environment variable:
 cl_lisps = os.environ.get("CL_LISPS", None)
+
+# cl_debug = True
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -77,6 +77,10 @@ extension list, (b) telling CLDomain the systems and packages to load.
   # Ensure that the default highlighting language is CL:
   highlight_language = 'common-lisp'
 
+  # For developer debugging only (and the curious, although, it did kill the cat!)
+  # Currently ``True`` or ``False`` to output the JSON collected from cl-launch.
+  cl_debug = False
+
 LISP to use
 ^^^^^^^^^^^
 
@@ -174,11 +178,10 @@ For an example, follow :ref:`this <variable2>` link or read on.
 Don't include the docstring: :nodoc:
 ------------------------------------
 
-CLDomain inserts the documentation strings associated with symbols in
-your systems and packages loaded by the ``cl_systems`` configuration
-directive. Sometimes, this isn't the right thing to do, when, instead,
-you'd prefer to provide separate (non-docstring) documentation. That's
-what the ``:nodoc`` option does.
+
+Sometimes, you'd prefer to provide separate (non-docstring) documentation
+instead of having CLDomain insert the Lisp docstrings.  That's what the
+``:nodoc`` option does.
 
 Note: Argument lists and specializers will still be printed, as in this
 example::
@@ -430,6 +433,49 @@ behavior::
 .. cl:method:: example-generic example-class :test
    :noinherit:
 
+
+Cross-references
+----------------
+
+You can cross reference Lisp entities using the following CLDomain Sphinx
+roles, which results in a hyperlinked reference to the matching identifier, if
+found:
+
+.. rst:role:: cl:function
+
+   References a function, as in ``:cl:function:`example-function``` (link:
+   :cl:function:`example-function`).
+
+.. rst:role:: cl:generic
+
+   References a generic function, as in ``:cl:generic:`example-generic```
+   (link: :cl:generic:`example-generic`).
+
+.. rst:role:: cl:macro
+
+   References a macro, as in ``:cl:macro:`example-macro``` (link:
+   :cl:macro:`example-macro`).
+
+.. rst:role:: cl:variable
+
+   References a variable, as in ``:cl:variable:`*example-variable*``` (link:
+   :cl:variable:`*example-variable*`).
+
+.. rst:role:: cl:type
+
+   References a type/CLOS class, as in ``:cl:type:`example-class``` (link:
+   :cl:type:`example-class`).
+
+.. FIXME rst:role:: cl:method
+.. FIXME
+.. FIXME   References a generic-specializing method, as in
+.. FIXME``:cl:method:`example-generic``` (link: :cl:method:`example-generic
+.. FIXME example-class :test`).
+
+
+.. rst:role:: cl:symbol
+
+   References a symbol, such as ``:cl:symbol:example-function`` (link: :cl:symbol:`example-function`).
 
 Hyperspec References
 --------------------

--- a/sphinxcontrib/cldomain.lisp
+++ b/sphinxcontrib/cldomain.lisp
@@ -292,10 +292,11 @@ possible symbol names."
   (encode-function-documentation*
    symbol type (or (documentation symbol type) "")))
 
-;; CLISP-ism (might be other CL's as well.)
+;; CLISP-ism (might be other CL's as well): compiled functions are still
+;; functions:
 (defmethod encode-function-documentation (symbol (type (eql 'compiled-function)))
   (encode-function-documentation*
-   symbol type (or (documentation symbol 'function) "")))
+   symbol 'function (or (documentation symbol 'function) "")))
 
 (defmethod encode-function-documentation (symbol (type (eql 'macro)))
   (encode-function-documentation*
@@ -314,7 +315,7 @@ possible symbol names."
   (encode-variable-documentation* symbol type))
 
 (defmethod encode-value-documentation (symbol (type (eql 'setf)))
-  (encode-function-documentation* symbol type))
+  (encode-function-documentation* symbol type (or (documentation symbol 'setf) "")))
 
 (defmethod encode-value-documentation (symbol (type (eql 'type)))
   (encode-variable-documentation* symbol type)

--- a/sphinxcontrib/cldomain.py
+++ b/sphinxcontrib/cldomain.py
@@ -858,7 +858,7 @@ def save_cldomain_output(output):
     return path
 
 
-def index_packages(systems, system_paths, packages, quicklisp, lisps):
+def index_packages(systems, system_paths, packages, quicklisp, lisps, cl_debug):
     """Call an external lisp program that will return a dictionary of doc
     strings for all public symbols.
 
@@ -884,7 +884,8 @@ def index_packages(systems, system_paths, packages, quicklisp, lisps):
 
     try:
         lisp_data = json.loads(output)
-        #pprint.pprint(lisp_data)
+        if cl_debug:
+            pprint.pprint(lisp_data)
     except:
         dump_path = save_cldomain_output(raw_output)
         error = sys.stderr
@@ -997,11 +998,14 @@ def load_packages(app):
     if not packages:
         app.warn("No CL packages specified.")
         return
+
+    app.info("Collecting Lisp docstrings from %s..." % ', '.join(str(x) for x in systems))
     index_packages(systems,
                    system_paths,
                    packages,
                    app.config.cl_quicklisp,
-                   app.config.cl_lisps)
+                   app.config.cl_lisps,
+                   app.config.cl_debug)
 
 
 def uppercase_symbols(app, docname, source):
@@ -1084,6 +1088,7 @@ def setup(app):
     app.add_config_value('cl_quicklisp', path.expandvars("$HOME/quicklisp"), 'env')
     app.add_config_value('cl_show_defaults', False, True)
     app.add_config_value('cl_lisps', None, 'env')
+    app.add_config_value('cl_debug', False, 'env')
     app.connect('builder-inited', load_packages)
     app.connect('build-finished', list_unused_symbols)
     #app.connect('source-read', uppercase_symbols)


### PR DESCRIPTION
cl_debug: Configuration variable so that you can look at the JSON output (pretty-printed Python).

Add cross-reference documentation.

Fix Clisp compiled-function issue, ECL-noticed documentation issue with "setf".